### PR TITLE
Add parallax layer selection for characters

### DIFF
--- a/Assets/Scripts/Game flow/GameFlowManager.cs
+++ b/Assets/Scripts/Game flow/GameFlowManager.cs
@@ -150,7 +150,7 @@ namespace VisualNovel.GameFLow
                 var finalPosition = basePosition + characterEntry.Offset;
 
                 sceneDirector.ShowCharacter(characterEntry.Character, emotion, characterEntry.SpriteColor,
-                    finalPosition, characterEntry.Layer, characterEntry.CharacterScale);
+                    finalPosition, characterEntry.Layer, characterEntry.CharacterScale, characterEntry.SelectedParallaxLayer);
             }
         }
     }


### PR DESCRIPTION
## Summary
- allow character nodes to choose a parallax layer from the scene's ParallaxController
- propagate chosen parallax layer to SceneryDirector so character sprites parent to the selected layer

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb383b0120832b90575463f4bdab44