### PR TITLE
Run all connected start and choice nodes

### DIFF
--- a/Assets/Scripts/Game flow/GameFlowManager.cs
+++ b/Assets/Scripts/Game flow/GameFlowManager.cs
@@ -48,8 +48,17 @@ namespace VisualNovel.GameFlow
 
         public void LaunchGraph()
         {
-            _currentNode = _graphTracer.LaunchFirstNode();
-            ExecuteNode(_currentNode);
+            var startingNodes = _graphTracer.LaunchStartNodes();
+            if (startingNodes.Count == 0) return;
+
+            foreach (var node in startingNodes)
+            {
+                var nodeType = _graphTracer.GetNodeType(node);
+                if (nodeType is TextNode)
+                    _currentNode = node;
+
+                ExecuteNode(node);
+            }
         }
 
         public void LaunchNextNodes()
@@ -109,7 +118,18 @@ namespace VisualNovel.GameFlow
                 return;
             }
             
-            choiceHandler.AddChoice(choiceNode.Text, () => {}); // as an action for the choice node, should be executing all the nodes that come afterwards 
+            choiceHandler.AddChoice(choiceNode.Text, () =>
+            {
+                var linkedNodes = _graphTracer.GetConnectedNodes(choiceNode.GUID);
+                foreach (var node in linkedNodes)
+                {
+                    var nodeType = _graphTracer.GetNodeType(node);
+                    if (nodeType is TextNode)
+                        _currentNode = node;
+
+                    ExecuteNode(node);
+                }
+            });
         }
 
         private void ExecuteTextNode(TextNode textNode)

--- a/Assets/Visual Novel Engine/Data/GraphTracer.cs
+++ b/Assets/Visual Novel Engine/Data/GraphTracer.cs
@@ -73,19 +73,20 @@ namespace VisualNovelEngine.Data
             return targetNode == null ? new List<GraphNodeData>() : GetConnectedNodes(targetNode.GUID);
         }
 
-        /// Finds the special start node and selects the first node linked from it.
+        /// Finds the special start node and returns all nodes linked from it.
+        /// The first connected node becomes the active node.
         /// </summary>
-        public GraphNodeData LaunchFirstNode()
+        public List<GraphNodeData> LaunchStartNodes()
         {
             var startNode = _nodesByGuid.Values
                 .FirstOrDefault(n => n.Type != null && n.Type.Contains("StartNode"));
 
             if (startNode == null)
-                return null;
+                return new List<GraphNodeData>();
 
-            var firstNode = GetConnectedNodes(startNode.GUID).FirstOrDefault();
-            ActiveNode = firstNode;
-            return ActiveNode;
+            var connectedNodes = GetConnectedNodes(startNode.GUID);
+            ActiveNode = connectedNodes.FirstOrDefault();
+            return connectedNodes;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Execute every node connected to the Start node on graph launch
- Run all nodes linked to a choice when that choice is selected

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2abddff0832b83618041f1a8d2c4