### PR TITLE
Show choice nodes immediately after text and improve decision circle

### DIFF
--- a/Assets/Scripts/Decision-making/DecisionCircle.cs
+++ b/Assets/Scripts/Decision-making/DecisionCircle.cs
@@ -88,9 +88,24 @@ namespace VisualNovel.Decisions
             _targetGraphicAngle = baseAngle + rotationOffset;
         }
 
-        /// <summary>Hides the arrow indicator.</summary>
+        /// <summary>Hides the entire decision circle and all of its children.</summary>
         public void Hide()
         {
+            foreach (Transform child in transform)
+            {
+                child.gameObject.SetActive(false);
+            }
+        }
+
+        /// <summary>Shows the decision circle and prepares the arrow for use.</summary>
+        public void Show()
+        {
+            foreach (Transform child in transform)
+            {
+                child.gameObject.SetActive(true);
+            }
+
+            // Keep the arrow hidden until it is needed by PointAt
             if (arrowRect != null)
                 arrowRect.gameObject.SetActive(false);
         }

--- a/Assets/Scripts/Game flow/ChoiceHandler.cs
+++ b/Assets/Scripts/Game flow/ChoiceHandler.cs
@@ -80,6 +80,8 @@ namespace VisualNovel.GameFlow
                     options[i].gameObject.SetActive(false);
                 }
             }
+
+            circle?.Show();
         }
 
         /// <summary>Hides all options and the decision circle.</summary>

--- a/Assets/Scripts/Game flow/GameFlowManager.cs
+++ b/Assets/Scripts/Game flow/GameFlowManager.cs
@@ -140,9 +140,9 @@ namespace VisualNovel.GameFlow
                 Debug.LogError("UIDialogueTextController is absent on the scene or was not initialized before usage!");
                 return;
             }
-            
+
             var text = textNode.Text;
-            
+
             if (textNode.IsDialogue)
             {
                 var speakerName = textNode.Speaker.characterName;
@@ -152,6 +152,26 @@ namespace VisualNovel.GameFlow
             {
                 dialogueTextController.PlayText(textNode.Text);
             }
+
+            // After displaying the text, immediately execute any connected ChoiceNodes
+            var choiceHandler = ChoiceHandler.Instance;
+            if (choiceHandler != null)
+                choiceHandler.ClearChoices();
+
+            var linkedNodes = _graphTracer.GetConnectedNodes(textNode.GUID);
+            var hasChoices = false;
+            foreach (var node in linkedNodes)
+            {
+                var nodeType = _graphTracer.GetNodeType(node);
+                if (nodeType is ChoiceNode choiceNode)
+                {
+                    hasChoices = true;
+                    ExecuteNode(node);
+                }
+            }
+
+            if (hasChoices)
+                choiceHandler?.ShowChoices();
         }
 
         private void ExecuteSceneNode(SceneControllerNode sceneNode)


### PR DESCRIPTION
## Summary
- Display connected choices as soon as a text node runs.
- Allow decision circle to fully hide/show all child visuals.
- Reveal decision circle when presenting choices.

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68bc304d08e8832b924bb4f0efd1b706