### PR TITLE
Fix decision circle visibility and node traversal

### DIFF
--- a/Assets/Scripts/Decision-making/DecisionCircle.cs
+++ b/Assets/Scripts/Decision-making/DecisionCircle.cs
@@ -110,6 +110,13 @@ namespace VisualNovel.Decisions
                 arrowRect.gameObject.SetActive(false);
         }
 
+        /// <summary>Hides only the arrow indicator without disabling options.</summary>
+        public void HideArrow()
+        {
+            if (arrowRect != null)
+                arrowRect.gameObject.SetActive(false);
+        }
+
         private void HandleTimeout()
         {
             Debug.Log("⏰ Decision time ran out!");

--- a/Assets/Scripts/Game flow/ChoiceHandler.cs
+++ b/Assets/Scripts/Game flow/ChoiceHandler.cs
@@ -106,7 +106,7 @@ namespace VisualNovel.GameFlow
         private void HandleExit(DecisionOption opt)
         {
             if (circle != null)
-                circle.Hide();
+                circle.HideArrow();
         }
 
         private void HandleClick(DecisionOption opt)

--- a/Assets/Visual Novel Engine/Data/GraphTracer.cs
+++ b/Assets/Visual Novel Engine/Data/GraphTracer.cs
@@ -116,6 +116,12 @@ namespace VisualNovelEngine.Data
 
             var instance = Activator.CreateInstance(type);
 
+            // Ensure instantiated nodes know their GUID so downstream systems
+            // can query graph connections using this identifier.
+            var guidProp = type.GetProperty("GUID");
+            if (guidProp != null && guidProp.CanWrite)
+                guidProp.SetValue(instance, node.GUID);
+
             foreach (var prop in node.Properties)
             {
                 var propInfo = type.GetProperty(prop.Name);


### PR DESCRIPTION
## Summary
- Hide only the arrow when moving off a decision option so options remain visible
- Propagate node GUIDs to instantiated graph nodes to avoid null-key lookups
- Ensure choice exit uses arrow hide instead of hiding entire circle

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3a0914b4832ba2e07d4e9e3af5df