### PR TITLE
feat: add runtime data containers and GUID-based assets

### DIFF
--- a/Assets/Game Assets/Scriptable Objects/Core/BaseSO.cs
+++ b/Assets/Game Assets/Scriptable Objects/Core/BaseSO.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GameAssets.ScriptableObjects.Core
+{
+    /// <summary>
+    /// Base class for ScriptableObjects that require a persistent GUID.
+    /// Provides runtime lookup by GUID for loading references from saved data.
+    /// </summary>
+    public abstract class BaseSO : ScriptableObject
+    {
+        [SerializeField, HideInInspector] private string guid;
+
+        private static readonly Dictionary<string, BaseSO> Registry = new();
+
+        /// <summary>
+        /// Globally unique identifier for this asset.
+        /// </summary>
+        public string Guid => guid;
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            if (string.IsNullOrEmpty(guid))
+            {
+                guid = System.Guid.NewGuid().ToString();
+                UnityEditor.EditorUtility.SetDirty(this);
+            }
+            Register();
+        }
+#endif
+
+        protected virtual void OnEnable()
+        {
+            if (string.IsNullOrEmpty(guid))
+            {
+                guid = System.Guid.NewGuid().ToString();
+            }
+            Register();
+        }
+
+        private void Register()
+        {
+            Registry[guid] = this;
+        }
+
+        /// <summary>
+        /// Retrieves an asset instance by its GUID.
+        /// </summary>
+        public static T GetByGuid<T>(string id) where T : BaseSO
+        {
+            return Registry.TryGetValue(id, out var so) ? so as T : null;
+        }
+    }
+}
+

--- a/Assets/Game Assets/Scriptable Objects/Core/BaseSO.cs.meta
+++ b/Assets/Game Assets/Scriptable Objects/Core/BaseSO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f2539a5-24f5-4415-938f-ac4d6752beed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Game Assets/Scriptable Objects/Core/CharacterSO.cs
+++ b/Assets/Game Assets/Scriptable Objects/Core/CharacterSO.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace GameAssets.ScriptableObjects.Core
 {
     [CreateAssetMenu(menuName = "VNE/New character")]
-    public class CharacterSO : ScriptableObject
+    public class CharacterSO : BaseSO
     {
         [Serializable]
         public class CharacterEmotion

--- a/Assets/Game Assets/Scriptable Objects/Core/ItemSO.cs
+++ b/Assets/Game Assets/Scriptable Objects/Core/ItemSO.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 namespace GameAssets.ScriptableObjects.Core
 {
     [CreateAssetMenu(menuName = "VNE/New item")]
-    public class ItemSO : ScriptableObject
+    public class ItemSO : BaseSO
     {
         public string itemName;
     }

--- a/Assets/Game Assets/Scriptable Objects/Core/TraitSO.cs
+++ b/Assets/Game Assets/Scriptable Objects/Core/TraitSO.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 namespace GameAssets.ScriptableObjects.Core
 {
-    public class TraitSO : ScriptableObject
+    public class TraitSO : BaseSO
     {
         public string characteristicName;
     }

--- a/Assets/Scripts/Data/CharacterDatabase.cs
+++ b/Assets/Scripts/Data/CharacterDatabase.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using GameAssets.ScriptableObjects.Core;
+using UnityEngine;
+
+namespace VisualNovel.Data
+{
+    /// <summary>
+    /// Tracks known characters and the player's relationship values with them.
+    /// </summary>
+    [Serializable]
+    public class CharacterDatabase : BaseGameData
+    {
+        [SerializeField] private List<string> characterGuids = new();
+        [SerializeField] private List<int> relationshipValues = new();
+
+        private readonly Dictionary<CharacterSO, int> relationships = new();
+
+        protected override string SaveKey => "CHARACTER_DATA";
+
+        public IReadOnlyDictionary<CharacterSO, int> Relationships => relationships;
+
+        public void RegisterCharacter(CharacterSO character)
+        {
+            if (character == null || relationships.ContainsKey(character)) return;
+            relationships[character] = 0;
+        }
+
+        public void RemoveCharacter(CharacterSO character)
+        {
+            if (character == null) return;
+            relationships.Remove(character);
+        }
+
+        public void SetRelationship(CharacterSO character, int value)
+        {
+            if (character == null) return;
+            relationships[character] = value;
+        }
+
+        public int GetRelationship(CharacterSO character)
+        {
+            return character != null && relationships.TryGetValue(character, out var value) ? value : 0;
+        }
+
+        public void ModifyRelationship(CharacterSO character, int delta)
+        {
+            if (character == null) return;
+            var current = GetRelationship(character);
+            relationships[character] = current + delta;
+        }
+
+        public override void Save()
+        {
+            characterGuids.Clear();
+            relationshipValues.Clear();
+            foreach (var pair in relationships)
+            {
+                characterGuids.Add(pair.Key.Guid);
+                relationshipValues.Add(pair.Value);
+            }
+            base.Save();
+        }
+
+        public override void Load()
+        {
+            base.Load();
+            relationships.Clear();
+            for (int i = 0; i < Math.Min(characterGuids.Count, relationshipValues.Count); i++)
+            {
+                var character = BaseSO.GetByGuid<CharacterSO>(characterGuids[i]);
+                if (character != null)
+                {
+                    relationships[character] = relationshipValues[i];
+                }
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/Data/CharacterDatabase.cs.meta
+++ b/Assets/Scripts/Data/CharacterDatabase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a39eca7-3f2d-4001-9aec-a305101392f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Data/FlagCollection.cs
+++ b/Assets/Scripts/Data/FlagCollection.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace VisualNovel.Data
+{
+    /// <summary>
+    /// Stores boolean flags used throughout the game.
+    /// </summary>
+    [Serializable]
+    public class FlagCollection : BaseGameData
+    {
+        [SerializeField] private List<string> keys = new();
+        [SerializeField] private List<bool> values = new();
+
+        private readonly Dictionary<string, bool> flags = new();
+
+        protected override string SaveKey => "FLAG_DATA";
+
+        public bool GetFlag(string key) => flags.TryGetValue(key, out var value) && value;
+
+        public void SetFlag(string key, bool value)
+        {
+            flags[key] = value;
+        }
+
+        public void RemoveFlag(string key)
+        {
+            flags.Remove(key);
+        }
+
+        public override void Save()
+        {
+            keys.Clear();
+            values.Clear();
+            foreach (var pair in flags)
+            {
+                keys.Add(pair.Key);
+                values.Add(pair.Value);
+            }
+            base.Save();
+        }
+
+        public override void Load()
+        {
+            base.Load();
+            flags.Clear();
+            for (int i = 0; i < Math.Min(keys.Count, values.Count); i++)
+            {
+                flags[keys[i]] = values[i];
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/Data/FlagCollection.cs.meta
+++ b/Assets/Scripts/Data/FlagCollection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6d0dc2d9-c44d-4579-949f-869047394d78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Data/Inventory.cs
+++ b/Assets/Scripts/Data/Inventory.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using GameAssets.ScriptableObjects.Core;
+using UnityEngine;
+
+namespace VisualNovel.Data
+{
+    /// <summary>
+    /// Runtime container tracking the player's items.
+    /// Save and load is handled through the BaseGameData system.
+    /// </summary>
+    [Serializable]
+    public class Inventory : BaseGameData
+    {
+        [SerializeField] private List<string> itemGuids = new();
+        private readonly List<ItemSO> items = new();
+
+        protected override string SaveKey => "INVENTORY_DATA";
+
+        /// <summary>
+        /// Exposes the current list of items.
+        /// </summary>
+        public IReadOnlyList<ItemSO> Items => items;
+
+        public void AddItem(ItemSO item)
+        {
+            if (item == null || items.Contains(item)) return;
+            items.Add(item);
+        }
+
+        public void RemoveItem(ItemSO item)
+        {
+            if (item == null) return;
+            items.Remove(item);
+        }
+
+        public bool HasItem(ItemSO item) => items.Contains(item);
+
+        public override void Save()
+        {
+            itemGuids.Clear();
+            foreach (var item in items)
+            {
+                itemGuids.Add(item.Guid);
+            }
+            base.Save();
+        }
+
+        public override void Load()
+        {
+            base.Load();
+            items.Clear();
+            foreach (var guid in itemGuids)
+            {
+                var item = BaseSO.GetByGuid<ItemSO>(guid);
+                if (item != null)
+                {
+                    items.Add(item);
+                }
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/Data/Inventory.cs.meta
+++ b/Assets/Scripts/Data/Inventory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee19d30c-15e9-4f60-9621-91b1a08b473d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Data/TraitCollection.cs
+++ b/Assets/Scripts/Data/TraitCollection.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using GameAssets.ScriptableObjects.Core;
+using UnityEngine;
+
+namespace VisualNovel.Data
+{
+    /// <summary>
+    /// Tracks the player's acquired traits.
+    /// </summary>
+    [Serializable]
+    public class TraitCollection : BaseGameData
+    {
+        [SerializeField] private List<string> traitGuids = new();
+        private readonly List<TraitSO> traits = new();
+
+        protected override string SaveKey => "TRAIT_DATA";
+
+        public IReadOnlyList<TraitSO> Traits => traits;
+
+        public void AddTrait(TraitSO trait)
+        {
+            if (trait == null || traits.Contains(trait)) return;
+            traits.Add(trait);
+        }
+
+        public void RemoveTrait(TraitSO trait)
+        {
+            if (trait == null) return;
+            traits.Remove(trait);
+        }
+
+        public bool HasTrait(TraitSO trait) => traits.Contains(trait);
+
+        public override void Save()
+        {
+            traitGuids.Clear();
+            foreach (var trait in traits)
+            {
+                traitGuids.Add(trait.Guid);
+            }
+            base.Save();
+        }
+
+        public override void Load()
+        {
+            base.Load();
+            traits.Clear();
+            foreach (var guid in traitGuids)
+            {
+                var trait = BaseSO.GetByGuid<TraitSO>(guid);
+                if (trait != null)
+                {
+                    traits.Add(trait);
+                }
+            }
+        }
+    }
+}
+

--- a/Assets/Scripts/Data/TraitCollection.cs.meta
+++ b/Assets/Scripts/Data/TraitCollection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3a2c990d-d449-49f9-a48e-63e66381409e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Docs/DataCollectionsAPI.md
+++ b/Docs/DataCollectionsAPI.md
@@ -1,0 +1,101 @@
+# Runtime Data Collections API
+
+This guide explains how to work with the runtime data containers that keep track of the player's state during the game.
+Each container updates in real time but only writes to disk when you call its `Save` method (or when the `GameDataManager` tells it to).
+
+The system uses `BaseSO` assets with GUIDs so saved data can be turned back into references after loading.
+
+## BaseSO Assets
+
+`ItemSO`, `CharacterSO`, and `TraitSO` inherit from `BaseSO`.
+A GUID is assigned automatically and registered at runtime.
+You can look up an asset by ID:
+
+```csharp
+var sword = BaseSO.GetByGuid<ItemSO>(guid);
+```
+
+## Inventory
+
+`Inventory` keeps a list of `ItemSO` references.
+
+```csharp
+Inventory inventory = new Inventory();
+
+// Add and remove items
+inventory.AddItem(sword);
+inventory.RemoveItem(sword);
+
+// Query
+bool hasSword = inventory.HasItem(sword);
+
+// Saving
+inventory.Save(); // store GUIDs
+inventory.Load(); // rebuild list from GUIDs
+```
+
+## CharacterDatabase
+
+`CharacterDatabase` tracks relationship values for characters.
+
+```csharp
+CharacterDatabase characters = new CharacterDatabase();
+
+characters.RegisterCharacter(npc);
+characters.ModifyRelationship(npc, +5);
+int value = characters.GetRelationship(npc);
+
+characters.Save();
+characters.Load();
+```
+
+## TraitCollection
+
+`TraitCollection` stores active traits.
+
+```csharp
+TraitCollection traits = new TraitCollection();
+
+traits.AddTrait(braveTrait);
+bool hasBrave = traits.HasTrait(braveTrait);
+
+traits.Save();
+traits.Load();
+```
+
+## FlagCollection
+
+`FlagCollection` holds boolean flags identified by a string key.
+
+```csharp
+FlagCollection flags = new FlagCollection();
+
+flags.SetFlag("met_villager", true);
+bool met = flags.GetFlag("met_villager");
+flags.RemoveFlag("met_villager");
+
+flags.Save();
+flags.Load();
+```
+
+## GameDataManager
+
+To save or load everything at once, register the containers with a `GameDataManager` component.
+
+```csharp
+public class SaveController : MonoBehaviour
+{
+    [SerializeField] private GameDataManager manager;
+
+    public void OnSaveClicked() => manager.SaveGame();
+    public void OnLoadClicked() => manager.LoadGame();
+}
+```
+
+Attach `SaveController` and assign the `GameDataManager` in the inspector. The manager calls `Save` and `Load` on each registered data section.
+
+## Summary
+
+- Collections update instantly and expose easy methods to read or modify data.
+- Nothing is written to disk until you call `Save` on the collection or via `GameDataManager`.
+- Assets derived from `BaseSO` carry GUIDs so saved references can be rebuilt after loading.


### PR DESCRIPTION
## Summary
- add BaseSO with GUID support and lookup
- convert item, trait and character assets to BaseSO
- introduce runtime containers for inventory, characters, traits and flags with save/load
- document how to use the data collections and save system

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd94cbf818832bb028763206922d37