### PR TITLE
Remove previous scene before spawning new one

### DIFF
--- a/Assets/Scripts/Environment/Scenery/SceneEnvironmentManager.cs
+++ b/Assets/Scripts/Environment/Scenery/SceneEnvironmentManager.cs
@@ -44,25 +44,31 @@ namespace VisualNovel.Environment
         
         public void ShowScene(SceneController newScene, string newPreset)
         {
+            // If nothing changes, simply exit
             if (_currentScene == newScene && _currentScenePreset == newPreset)
             {
                 return;
             }
 
+            // Scene stays the same but preset changes
             if (_currentScene == newScene && _currentScenePreset != newPreset)
             {
                 _currentScene.ChangePreset(newPreset);
+                _currentScenePreset = newPreset;
                 return;
             }
 
+            // We're switching scenes – remove the previous scene before creating a new one
             if (_currentScene != null)
             {
-                Destroy(_currentScene);
+                var oldScene = _currentScene;
                 _currentScene = null;
+                Destroy(oldScene.gameObject);
             }
-            
+
             _currentScene = Instantiate(newScene);
             _currentScene.ChangePreset(newPreset);
+            _currentScenePreset = newPreset;
         }
 
         public bool TryGetCharacterPosition(string positionName, out Vector2 position)


### PR DESCRIPTION
## Summary
- Ensure `SceneEnvironmentManager` removes the current scene object before creating a new scene
- Keep track of active preset when switching or updating scene presets

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c06596874c832b8aa045b09236f330