### PR TITLE
Add extensible minigame framework

### DIFF
--- a/Assets/Scripts/Minigames.meta
+++ b/Assets/Scripts/Minigames.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1a2b3c4d5e6f7890123456789abcdef0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Minigames/CombatMinigame.cs
+++ b/Assets/Scripts/Minigames/CombatMinigame.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace VisualNovel.Minigames
+{
+    /// <summary>
+    /// Example implementation of a minigame. This is only a placeholder
+    /// to demonstrate how to derive from <see cref="MinigameBase"/>.
+    /// </summary>
+    public class CombatMinigame : MinigameBase
+    {
+        protected override void OnStart()
+        {
+            // Setup combat-specific logic here. For now we immediately
+            // finish with success to demonstrate the flow.
+            Debug.Log("Combat minigame launched");
+            Finish(true);
+        }
+    }
+}

--- a/Assets/Scripts/Minigames/CombatMinigame.cs.meta
+++ b/Assets/Scripts/Minigames/CombatMinigame.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4d5e6f7081923456789abcdef0123456

--- a/Assets/Scripts/Minigames/MinigameBase.cs
+++ b/Assets/Scripts/Minigames/MinigameBase.cs
@@ -1,0 +1,59 @@
+using System;
+using UnityEngine;
+
+namespace VisualNovel.Minigames
+{
+    /// <summary>
+    /// Base class for all minigames. Handles UI spawning and
+    /// completion notification.
+    /// </summary>
+    public abstract class MinigameBase : MonoBehaviour
+    {
+        [SerializeField] private GameObject uiPrefab;
+        private GameObject _uiInstance;
+        private Transform _uiRoot;
+
+        /// <summary>Event invoked when the minigame finishes.</summary>
+        public event Action<bool> Finished;
+
+        /// <summary>Launches the minigame and spawns its UI.</summary>
+        /// <param name="uiParent">Parent transform for the minigame UI.</param>
+        public virtual void Launch(Transform uiParent)
+        {
+            _uiRoot = uiParent;
+            if (uiPrefab != null && _uiRoot != null)
+            {
+                _uiInstance = Instantiate(uiPrefab, _uiRoot);
+            }
+
+            OnStart();
+        }
+
+        /// <summary>
+        /// Called when the minigame starts. Derived classes should begin their
+        /// game flow here.
+        /// </summary>
+        protected abstract void OnStart();
+
+        /// <summary>
+        /// Finish the minigame and notify listeners.
+        /// </summary>
+        /// <param name="isSuccess">Whether the player succeeded.</param>
+        protected void Finish(bool isSuccess)
+        {
+            if (_uiInstance != null)
+            {
+                Destroy(_uiInstance);
+            }
+
+            OnFinish(isSuccess);
+            Finished?.Invoke(isSuccess);
+        }
+
+        /// <summary>
+        /// Called before <see cref="Finished"/> is invoked. Allows derived
+        /// classes to clean up.
+        /// </summary>
+        protected virtual void OnFinish(bool isSuccess) {}
+    }
+}

--- a/Assets/Scripts/Minigames/MinigameBase.cs.meta
+++ b/Assets/Scripts/Minigames/MinigameBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2b3c4d5e6f7081923456789abcdef0123

--- a/Assets/Scripts/Minigames/MinigameManager.cs
+++ b/Assets/Scripts/Minigames/MinigameManager.cs
@@ -1,0 +1,56 @@
+using System;
+using UnityEngine;
+using VisualNovel.GameFlow;
+
+namespace VisualNovel.Minigames
+{
+    /// <summary>
+    /// Handles instantiation and tracking of active minigames.
+    /// </summary>
+    public class MinigameManager : MonoBehaviour, IInitializeOnAwake
+    {
+        [SerializeField] private Transform uiRoot;
+
+        private MinigameBase _current;
+
+        public static MinigameManager Instance { get; private set; }
+
+        public void Initialize()
+        {
+            if (Instance != null)
+                return;
+
+            Instance = this;
+        }
+
+        /// <summary>
+        /// Launches a new minigame based on the given prefab.
+        /// </summary>
+        /// <param name="minigamePrefab">Prefab that contains a <see cref="MinigameBase"/>.</param>
+        /// <param name="callback">Invoked with the success state once the minigame finishes.</param>
+        public void StartMinigame(MinigameBase minigamePrefab, Action<bool> callback = null)
+        {
+            if (_current != null)
+            {
+                Debug.LogWarning("A minigame is already running.");
+                return;
+            }
+
+            _current = Instantiate(minigamePrefab);
+            if (callback != null)
+                _current.Finished += callback;
+            _current.Finished += HandleMinigameFinished;
+            _current.Launch(uiRoot);
+        }
+
+        private void HandleMinigameFinished(bool success)
+        {
+            if (_current == null)
+                return;
+
+            _current.Finished -= HandleMinigameFinished;
+            Destroy(_current.gameObject);
+            _current = null;
+        }
+    }
+}

--- a/Assets/Scripts/Minigames/MinigameManager.cs.meta
+++ b/Assets/Scripts/Minigames/MinigameManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3c4d5e6f7081923456789abcdef01234

--- a/Assets/Visual Novel Engine/Data/GraphTracer.cs
+++ b/Assets/Visual Novel Engine/Data/GraphTracer.cs
@@ -68,6 +68,30 @@ namespace VisualNovelEngine.Data
         }
 
         /// <summary>
+        /// Returns nodes connected to a specific output port of the given node.
+        /// </summary>
+        /// <param name="nodeGuid">GUID of the source node.</param>
+        /// <param name="portName">Name of the output port.</param>
+        public List<GraphNodeData> GetConnectedNodes(string nodeGuid, string portName)
+        {
+            if (!_linksBySource.TryGetValue(nodeGuid, out var links))
+                return new List<GraphNodeData>();
+
+            var result = new List<GraphNodeData>();
+            foreach (var link in links)
+            {
+                if (link.PortName != portName)
+                    continue;
+
+                if (_nodesByGuid.TryGetValue(link.TargetNodeGUID, out var node))
+                {
+                    result.Add(node);
+                }
+            }
+            return result;
+        }
+
+        /// <summary>
         /// Returns all nodes connected to the output ports of the given node.
         /// </summary>
         /// <param name="targetNode">The node whose outputs will be inspected.</param>

--- a/Assets/Visual Novel Engine/Elements/MinigameNode.cs
+++ b/Assets/Visual Novel Engine/Elements/MinigameNode.cs
@@ -1,0 +1,65 @@
+using System;
+using UnityEditor.Experimental.GraphView;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace VisualNovelEngine.Elements
+{
+    using Utilities;
+    using Utilities.Attributes;
+    using VisualNovel.Minigames;
+
+    [Serializable]
+    [NodeMenu("Minigame Node", "Logic & Flow")]
+    public class MinigameNode : GraphNode
+    {
+        /// <summary>Prefab containing the minigame to launch.</summary>
+        public MinigameBase MinigamePrefab { get; set; }
+
+        public override void Initialize(Vector2 gridPosition, string nodeGuid = null)
+        {
+            base.Initialize(gridPosition, nodeGuid);
+
+            NodeName = "Minigame Node";
+            Text = string.Empty;
+            Choices.Clear();
+            Choices.Add("onSuccess");
+            Choices.Add("onFail");
+        }
+
+        public override void Draw()
+        {
+            // ----- Title -----
+            var nodeNameTextField = UIElementUtilities.CreateTextField(NodeName);
+            nodeNameTextField.AddClasses("gp-node__text-field", "gp-node__filename-text-field", "gp-node__text-field__hidden");
+            nodeNameTextField.RegisterValueChangedCallback(evt => NodeName = evt.newValue);
+            titleContainer.Insert(0, nodeNameTextField);
+            titleContainer.Q<TextField>()?.SetEnabled(false);
+
+            // ----- Ports -----
+            var inputPort = this.CreatePort("Input Link", direction: Direction.Input, capacity: Port.Capacity.Multi);
+            inputContainer.Insert(0, inputPort);
+
+            foreach (var choice in Choices)
+            {
+                var choicePort = this.CreatePort(choice, capacity: Port.Capacity.Multi);
+                choicePort.portName = choice;
+                outputContainer.Add(choicePort);
+            }
+
+            // ----- Body -----
+            var field = new ObjectField("Minigame Prefab")
+            {
+                objectType = typeof(MinigameBase),
+                allowSceneObjects = false,
+                value = MinigamePrefab
+            };
+            field.RegisterValueChangedCallback(evt => MinigamePrefab = evt.newValue as MinigameBase);
+            extensionContainer.Add(field);
+
+            RefreshExpandedState();
+            RefreshPorts();
+        }
+    }
+}
+

--- a/Assets/Visual Novel Engine/Elements/MinigameNode.cs.meta
+++ b/Assets/Visual Novel Engine/Elements/MinigameNode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f48d26e147ba4a5fa3e8a0f7c05ac530


### PR DESCRIPTION
## Summary
- add `MinigameBase` abstract class for spawning UI and signaling completion
- add `MinigameManager` to launch and track minigames
- include example `CombatMinigame` implementation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c186e8ab80832bbd9210ee2c47798a