### PR TITLE
Respect size and layer in Combat Minigame

### DIFF
--- a/Assets/Scripts/Minigames/CombatMinigame.cs
+++ b/Assets/Scripts/Minigames/CombatMinigame.cs
@@ -53,7 +53,7 @@ namespace VisualNovel.Minigames.Combat
             }
 
             sceneManager.ShowCharacter(data.characterReference, data.characterEmotion, Color.white,
-                _characterOffset, 0, Vector2.one, _parallaxLayer);
+                _characterOffset, data.layer, data.characterScale, _parallaxLayer);
 
             if (enemyHealthBar != null)
                 enemyHealthBar.Initialize(data.baseHealthPoints, data.baseHealthPoints);

--- a/Assets/Scripts/Minigames/FighterData.cs
+++ b/Assets/Scripts/Minigames/FighterData.cs
@@ -12,5 +12,7 @@ namespace VisualNovel.Minigames.Combat
         public int baseHealthPoints = 100;
         public int baseActionPoints = 5;
         public int baseDamage = 5;
+        public Vector2 characterScale = Vector2.one;
+        public int layer;
     }
 }

--- a/Assets/Visual Novel Engine/Elements/CombatMinigameNode.cs
+++ b/Assets/Visual Novel Engine/Elements/CombatMinigameNode.cs
@@ -35,6 +35,8 @@ namespace VisualNovelEngine.Elements
             [NonSerialized] public IntegerField healthField;
             [NonSerialized] public IntegerField actionField;
             [NonSerialized] public IntegerField damageField;
+            [NonSerialized] public IntegerField layerField;
+            [NonSerialized] public Vector2Field scaleField;
             [NonSerialized] public VisualElement container;
         }
 
@@ -245,6 +247,22 @@ namespace VisualNovelEngine.Elements
             entry.damageField.RegisterValueChangedCallback(evt => entry.baseDamage = evt.newValue);
             container.Add(entry.damageField);
 
+            entry.layerField = new IntegerField("Layer") { value = entry.layer };
+            entry.layerField.RegisterValueChangedCallback(evt =>
+            {
+                entry.layer = evt.newValue;
+                RebuildPreview();
+            });
+            container.Add(entry.layerField);
+
+            entry.scaleField = new Vector2Field("Scale") { value = entry.characterScale };
+            entry.scaleField.RegisterValueChangedCallback(evt =>
+            {
+                entry.characterScale = evt.newValue;
+                RebuildPreview();
+            });
+            container.Add(entry.scaleField);
+
             _fightersContainer.Add(container);
 
             RefreshEmotionDropdown(entry);
@@ -293,13 +311,14 @@ namespace VisualNovelEngine.Elements
             _previewScaleSlider.SetEnabled(true);
             var targetHeight = Mathf.RoundToInt(BasePreviewHeight * PreviewScale);
 
+            var scale = first.characterScale != Vector2.zero ? first.characterScale : Vector2.one;
             var info = new CharacterPreviewInfo
             {
                 sprite = sprite,
                 position = CharacterOffset,
-                layer = _parallaxLayers.IndexOf(SelectedParallaxLayer),
+                layer = first.layer,
                 color = Color.white,
-                scale = Vector2.one
+                scale = scale
             };
 
             var tex = RenderCharacterPreview(Scene, new List<CharacterPreviewInfo> { info }, targetHeight);


### PR DESCRIPTION
## Summary
- allow CombatMinigame to spawn enemies with custom size and sorting layer
- extend FighterData and minigame node to configure fighter layer and scale

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c13e65f8832bbe4fe3a4c8a8728a