### PR TITLE
Add runtime fighter tracking and AI action point logic

### DIFF
--- a/Assets/Scripts/Game flow/GameFlowManager.cs
+++ b/Assets/Scripts/Game flow/GameFlowManager.cs
@@ -249,7 +249,7 @@ namespace VisualNovel.GameFlow
             {
                 if (mg is CombatMinigame combat)
                 {
-                    combat.Initialize(minigameNode.Fighters.Cast<FighterData>().ToList(),
+                    combat.Initialize(minigameNode.Fighters.Cast<FighterBaseStats>().ToList(),
                         minigameNode.SelectedParallaxLayer, minigameNode.CharacterOffset);
                 }
             }, success =>

--- a/Assets/Scripts/Minigames/FighterBaseStats.cs
+++ b/Assets/Scripts/Minigames/FighterBaseStats.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace VisualNovel.Minigames.Combat
 {
     [Serializable]
-    public class FighterData
+    public class FighterBaseStats
     {
         public CharacterSO characterReference;
         public CharacterSO.CharacterEmotion characterEmotion;

--- a/Assets/Scripts/Minigames/FighterRuntime.cs
+++ b/Assets/Scripts/Minigames/FighterRuntime.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+namespace VisualNovel.Minigames.Combat
+{
+    /// <summary>
+    /// Represents the real-time state of a fighter during the combat minigame.
+    /// Keeps track of current health and action points per round
+    /// independent from the initialization data.
+    /// </summary>
+    public class FighterRuntime
+    {
+        public FighterBaseStats BaseStats { get; }
+        public int CurrentHealth { get; private set; }
+        public int ActionPointsPerRound { get; private set; }
+
+        public FighterRuntime(FighterBaseStats baseStats)
+        {
+            BaseStats = baseStats ?? new FighterBaseStats();
+            CurrentHealth = BaseStats.baseHealthPoints;
+            ActionPointsPerRound = BaseStats.baseActionPoints;
+        }
+
+        public bool IsAlive => CurrentHealth > 0;
+
+        public void TakeDamage(int amount)
+        {
+            CurrentHealth = Mathf.Max(0, CurrentHealth - amount);
+        }
+
+        public void ApplyRest(int restPoints)
+        {
+            ActionPointsPerRound += restPoints;
+        }
+    }
+}

--- a/Assets/Scripts/Minigames/PlayerStatsController.cs
+++ b/Assets/Scripts/Minigames/PlayerStatsController.cs
@@ -13,6 +13,15 @@ namespace VisualNovel.Minigames.Combat
         private int _actionPointsPerRound;
 
         public Action onActionPointAssigned;
+
+        public void Initialize(int actionPointsPerRound)
+        {
+            _actionPointsPerRound = actionPointsPerRound;
+            _totalLeftActionPoints = actionPointsPerRound;
+            _attackActionPoints = 0;
+            _defenceActionPoints = 0;
+            _restActionPoints = 0;
+        }
         
         public void AddAttackActionPoint()
         {

--- a/Assets/Visual Novel Engine/Elements/CombatMinigameNode.cs
+++ b/Assets/Visual Novel Engine/Elements/CombatMinigameNode.cs
@@ -26,7 +26,7 @@ namespace VisualNovelEngine.Elements
         public Vector2 CharacterOffset { get; set; }
 
         [Serializable]
-        public class FighterEntry : FighterData
+        public class FighterEntry : FighterBaseStats
         {
             public string SelectedEmotion;
 


### PR DESCRIPTION
## Summary
- rename FighterData to FighterBaseStats for clarity
- introduce FighterRuntime to track current health and action points
- implement AI random action point distribution and combat resolution
- add initialization for player action points

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1dc32613c832b9a7f8eb092ae01d5