### PR TITLE
Refactor PlayerStatsController to use FighterRuntime

### DIFF
--- a/Assets/Scripts/Minigames/CombatMinigame.cs
+++ b/Assets/Scripts/Minigames/CombatMinigame.cs
@@ -49,7 +49,7 @@ namespace VisualNovel.Minigames.Combat
             if (playerHealthBar != null)
                 playerHealthBar.Initialize(_player.BaseStats.baseHealthPoints);
 
-            playerStatsController.Initialize(_player.ActionPointsPerRound);
+            playerStatsController.Initialize(_player);
 
             if (startRoundButton != null)
                 startRoundButton.onClick.AddListener(PlayRound);
@@ -97,7 +97,6 @@ namespace VisualNovel.Minigames.Combat
                 playerHealthBar.ModifyCurrentHealthValue(-damage);
             }
 
-            _player.ApplyRest(p_restPoints);
             _enemy.ApplyRest(e_restPoints);
 
             playerStatsController.ResetPoints();

--- a/Assets/Scripts/Minigames/PlayerStatsController.cs
+++ b/Assets/Scripts/Minigames/PlayerStatsController.cs
@@ -10,14 +10,14 @@ namespace VisualNovel.Minigames.Combat
         private int _restActionPoints;
 
         private int _totalLeftActionPoints;
-        private int _actionPointsPerRound;
+        private FighterRuntime _playerRuntime;
 
         public Action onActionPointAssigned;
 
-        public void Initialize(int actionPointsPerRound)
+        public void Initialize(FighterRuntime playerRuntime)
         {
-            _actionPointsPerRound = actionPointsPerRound;
-            _totalLeftActionPoints = actionPointsPerRound;
+            _playerRuntime = playerRuntime;
+            _totalLeftActionPoints = _playerRuntime.ActionPointsPerRound;
             _attackActionPoints = 0;
             _defenceActionPoints = 0;
             _restActionPoints = 0;
@@ -84,9 +84,9 @@ namespace VisualNovel.Minigames.Combat
 
         public void ResetPoints()
         {
-            _actionPointsPerRound += _restActionPoints;
-            _totalLeftActionPoints = _actionPointsPerRound;
-            
+            _playerRuntime.ApplyRest(_restActionPoints);
+            _totalLeftActionPoints = _playerRuntime.ActionPointsPerRound;
+
             _attackActionPoints = 0;
             _defenceActionPoints = 0;
             _restActionPoints = 0;


### PR DESCRIPTION
## Summary
- Inject FighterRuntime into PlayerStatsController to eliminate duplicate action point tracking
- Apply rest and reset points based on FighterRuntime values
- Pass player runtime to stats controller and streamline round logic

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c1df61e01c832bb1261305c7eba679