### PR TITLE
Add item notifications when items are added

### DIFF
--- a/Assets/Game Assets/Scriptable Objects/Core/ItemSO.cs
+++ b/Assets/Game Assets/Scriptable Objects/Core/ItemSO.cs
@@ -6,5 +6,7 @@ namespace GameAssets.ScriptableObjects.Core
     public class ItemSO : BaseSO
     {
         public string itemName;
+        public string itemDescription;
+        public Sprite itemIcon;
     }
 }

--- a/Assets/Scripts/Game flow/GameFlowManager.cs
+++ b/Assets/Scripts/Game flow/GameFlowManager.cs
@@ -335,26 +335,27 @@ namespace VisualNovel.GameFlow
                 gameDataManager.characterCollection.ModifyRelationship(character, amount);
             }
             
+            var notificationManager = UINotificationManager.Instance;
+
+            if (notificationManager == null)
+            {
+                Debug.LogError("UINotificationManager is absent on the scene or was not initialized before usage!");
+                return;
+            }
+
             // ----- check trait modifiers ------
             foreach (var traitData in modifierNode.TraitsToAdd)
             {
                 gameDataManager.playerTraitCollection.AddTrait(traitData.Trait);
-                var notificationManager = UINotificationManager.Instance;
-                
-                if (notificationManager == null)
-                {
-                    Debug.LogError("UINotificationManager is absent on the scene or was not initialized before usage!");
-                    return;
-                }
-                
                 notificationManager.ShowTraitNotification(traitData.Trait);
             }
-            
+
             // ----- check item modifiers -----
             // items to add
             foreach (var itemData in modifierNode.ItemsToAdd)
             {
                 gameDataManager.playerInventory.AddItem(itemData.Item);
+                notificationManager.ShowItemNotification(itemData.Item);
             }
             
             // items to remove

--- a/Assets/Scripts/UI/In-game notifications/GlobalNotification.cs
+++ b/Assets/Scripts/UI/In-game notifications/GlobalNotification.cs
@@ -4,6 +4,7 @@ namespace VisualNovel.UI.Notifications
 {
     public abstract class GlobalNotification : MonoBehaviour
     {
+        public abstract ExtendedButton ReadButton { get; }
         public abstract void Show();
         public abstract void Hide();
     }

--- a/Assets/Scripts/UI/In-game notifications/ItemNotification.cs
+++ b/Assets/Scripts/UI/In-game notifications/ItemNotification.cs
@@ -32,14 +32,14 @@ namespace VisualNovel.UI.Notifications
 
         private Coroutine showNotificationRoutine;
         
-        public void Initialize(TraitSO targetTrait)
+        public void Initialize(ItemSO targetItem)
         {
-            itemIcon.sprite = targetTrait.traitIcon;
-            itemNameTextField.text = targetTrait.traitName;
-            itemDescriptionTextField.text = targetTrait.traitDescription;
+            itemIcon.sprite = targetItem.itemIcon;
+            itemNameTextField.text = targetItem.itemName;
+            itemDescriptionTextField.text = targetItem.itemDescription;
         }
 
-        public ExtendedButton ReadButton => readButton;
+        public override ExtendedButton ReadButton => readButton;
         
         public override void Show()
         {

--- a/Assets/Scripts/UI/In-game notifications/TraitNotification.cs
+++ b/Assets/Scripts/UI/In-game notifications/TraitNotification.cs
@@ -37,7 +37,7 @@ namespace VisualNovel.UI.Notifications
             traitDescriptionTextField.text = targetTrait.traitDescription;
         }
 
-        public ExtendedButton ReadButton => readButton;
+        public override ExtendedButton ReadButton => readButton;
         
         public override void Show()
         {

--- a/Assets/Scripts/UI/UINotificationManager.cs
+++ b/Assets/Scripts/UI/UINotificationManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using VisualNovel.GameFlow;
@@ -10,9 +11,11 @@ namespace VisualNovel.UI
     public class UINotificationManager : MonoBehaviour, IInitializeOnAwake
     {
         [SerializeField] private GameObject traitNotificationPrefab;
+        [SerializeField] private GameObject itemNotificationPrefab;
 
-        private readonly Queue<TraitSO> traitQueue = new();
-        private TraitNotification currentNotification;
+        private readonly Queue<Action> notificationQueue = new();
+        private GlobalNotification currentNotification;
+        private GameObject currentNotificationPrefab;
 
         public static UINotificationManager Instance { get; private set; }
 
@@ -33,41 +36,90 @@ namespace VisualNovel.UI
                 return;
             }
 
-            traitQueue.Enqueue(trait);
+            notificationQueue.Enqueue(() => SpawnTraitNotification(trait));
             if (currentNotification == null)
             {
-                ShowNextTrait();
+                ShowNext();
             }
         }
 
-        private void ShowNextTrait()
+        public void ShowItemNotification(ItemSO item)
         {
-            if (traitQueue.Count == 0)
+            if (item == null)
             {
                 return;
             }
 
+            notificationQueue.Enqueue(() => SpawnItemNotification(item));
+            if (currentNotification == null)
+            {
+                ShowNext();
+            }
+        }
+
+        private void SpawnTraitNotification(TraitSO trait)
+        {
             var controller = UserInterfaceController.Instance;
             if (controller == null || traitNotificationPrefab == null)
             {
-                traitQueue.Clear();
+                notificationQueue.Clear();
                 return;
             }
 
             var go = controller.SpawnAdditionalUI(traitNotificationPrefab);
-            currentNotification = go.GetComponent<TraitNotification>();
-            if (currentNotification == null)
+            var notification = go.GetComponent<TraitNotification>();
+            if (notification == null)
             {
                 Debug.LogError("TraitNotification component missing on prefab");
                 return;
             }
 
-            currentNotification.Initialize(traitQueue.Dequeue());
-            if (currentNotification.ReadButton != null)
+            currentNotification = notification;
+            currentNotificationPrefab = traitNotificationPrefab;
+            notification.Initialize(trait);
+            if (notification.ReadButton != null)
             {
-                currentNotification.ReadButton.OnLeftClick.AddListener(HandleNotificationRead);
+                notification.ReadButton.OnLeftClick.AddListener(HandleNotificationRead);
             }
             currentNotification.Show();
+        }
+
+        private void SpawnItemNotification(ItemSO item)
+        {
+            var controller = UserInterfaceController.Instance;
+            if (controller == null || itemNotificationPrefab == null)
+            {
+                notificationQueue.Clear();
+                return;
+            }
+
+            var go = controller.SpawnAdditionalUI(itemNotificationPrefab);
+            var notification = go.GetComponent<ItemNotification>();
+            if (notification == null)
+            {
+                Debug.LogError("ItemNotification component missing on prefab");
+                return;
+            }
+
+            currentNotification = notification;
+            currentNotificationPrefab = itemNotificationPrefab;
+            notification.Initialize(item);
+            if (notification.ReadButton != null)
+            {
+                notification.ReadButton.OnLeftClick.AddListener(HandleNotificationRead);
+            }
+            currentNotification.Show();
+        }
+
+        private void ShowNext()
+        {
+            if (notificationQueue.Count == 0)
+            {
+                return;
+            }
+
+            var action = notificationQueue.Dequeue();
+            action?.Invoke();
         }
 
         private void HandleNotificationRead()
@@ -80,11 +132,15 @@ namespace VisualNovel.UI
                 }
 
                 currentNotification.Hide();
-                UserInterfaceController.Instance.DeleteAdditionalUI(traitNotificationPrefab);
+                if (currentNotificationPrefab != null)
+                {
+                    UserInterfaceController.Instance.DeleteAdditionalUI(currentNotificationPrefab);
+                }
                 currentNotification = null;
+                currentNotificationPrefab = null;
             }
 
-            ShowNextTrait();
+            ShowNext();
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend notification system to queue and display item notifications alongside trait notifications
- support item details by expanding `ItemSO` and `ItemNotification`
- trigger item notifications when inventory gains new items

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c55c3937f8832b8bae87cf31ddf8a6