### PR TITLE
Refactor item and trait notifications to share animation logic

### DIFF
--- a/Assets/Scripts/UI/In-game notifications/AnimatedNotification.cs
+++ b/Assets/Scripts/UI/In-game notifications/AnimatedNotification.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections;
+using Coffee.UIExtensions;
+using UnityEngine;
+
+namespace VisualNovel.UI.Notifications
+{
+    using Animations;
+
+    public abstract class AnimatedNotification : GlobalNotification
+    {
+        [Header("Animators")]
+        [SerializeField] private AnimatorSequence[] animatorSequences;
+
+        [Serializable]
+        public class AnimatorSequence
+        {
+            public UIAnimator animator;
+            public UIParticle uiParticle;
+            public float delayInSec;
+        }
+
+        private Coroutine showNotificationRoutine;
+
+        public override void Show()
+        {
+            if (showNotificationRoutine != null)
+            {
+                StopCoroutine(showNotificationRoutine);
+                showNotificationRoutine = null;
+            }
+            showNotificationRoutine = StartCoroutine(ShowNotificationRoutine());
+        }
+
+        public override void Hide()
+        {
+            if (showNotificationRoutine != null)
+            {
+                StopCoroutine(showNotificationRoutine);
+                showNotificationRoutine = null;
+            }
+
+            if (animatorSequences == null) return;
+            foreach (var seq in animatorSequences)
+            {
+                if (seq?.animator != null)
+                    seq.animator.Play("Hide");
+            }
+        }
+
+        private IEnumerator ShowNotificationRoutine()
+        {
+            if (animatorSequences == null || animatorSequences.Length == 0)
+                yield break;
+
+            // If ALL delays are zero -> play all at once.
+            bool allZeroDelay = true;
+            foreach (var seq in animatorSequences)
+            {
+                if (seq != null && seq.delayInSec > 0f)
+                {
+                    allZeroDelay = false;
+                    break;
+                }
+            }
+
+            if (allZeroDelay)
+            {
+                foreach (var seq in animatorSequences)
+                {
+                    if (seq?.animator != null)
+                    {
+                        seq.animator.Play("Appear");
+                        if (seq.uiParticle != null)
+                        {
+                            seq.uiParticle.Play();
+                        }
+                    }
+                }
+                yield break;
+            }
+
+            // Otherwise: play one-by-one, respecting each item's delay (relative to the previous trigger).
+            foreach (var seq in animatorSequences)
+            {
+                if (seq == null || seq.animator == null)
+                    continue;
+
+                if (seq.delayInSec > 0f)
+                    yield return new WaitForSeconds(seq.delayInSec);
+
+                seq.animator.Play("Appear");
+
+                if (seq.uiParticle != null)
+                {
+                    seq.uiParticle.Play();
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/In-game notifications/AnimatedNotification.cs.meta
+++ b/Assets/Scripts/UI/In-game notifications/AnimatedNotification.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 11ba0735d31a4be3b53b8f51ba628d8a

--- a/Assets/Scripts/UI/In-game notifications/ItemNotification.cs
+++ b/Assets/Scripts/UI/In-game notifications/ItemNotification.cs
@@ -1,17 +1,13 @@
-using System;
-using System.Collections;
-using Coffee.UIExtensions;
 using GameAssets.ScriptableObjects.Core;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
-
 namespace VisualNovel.UI.Notifications
 {
-    using Animations;
-    
-    public class ItemNotification : GlobalNotification
+    using UI;
+
+    public class ItemNotification : AnimatedNotification
     {
         [Header("UI Setup")]
         [SerializeField] private Image itemIcon;
@@ -19,19 +15,6 @@ namespace VisualNovel.UI.Notifications
         [SerializeField] private TMP_Text itemDescriptionTextField;
         [SerializeField] private ExtendedButton readButton;
 
-        [Header("Animators")] 
-        [SerializeField] private AnimatorSequence[] animatorSequences;
-
-        [Serializable]
-        public class AnimatorSequence
-        {
-            public UIAnimator animator;
-            public UIParticle uiParticle;
-            public float delayInSec;
-        }
-
-        private Coroutine showNotificationRoutine;
-        
         public void Initialize(ItemSO targetItem)
         {
             itemIcon.sprite = targetItem.itemIcon;
@@ -40,82 +23,5 @@ namespace VisualNovel.UI.Notifications
         }
 
         public override ExtendedButton ReadButton => readButton;
-        
-        public override void Show()
-        {
-            if (showNotificationRoutine != null)
-            {
-                StopCoroutine(showNotificationRoutine);
-                showNotificationRoutine = null;
-            }
-            showNotificationRoutine = StartCoroutine(ShowNotificationRoutine());
-        }
-
-        public override void Hide()
-        {
-            if (showNotificationRoutine != null)
-            {
-                StopCoroutine(showNotificationRoutine);
-                showNotificationRoutine = null;
-            }
-
-            // hiding everything at once
-            if (animatorSequences == null) return;
-            foreach (var seq in animatorSequences)
-            {
-                if (seq?.animator != null)
-                    seq.animator.Play("Hide");
-            }
-        }
-
-        private IEnumerator ShowNotificationRoutine()
-        {
-            if (animatorSequences == null || animatorSequences.Length == 0)
-                yield break;
-
-            // If ALL delays are zero -> play all at once.
-            bool allZeroDelay = true;
-            foreach (var seq in animatorSequences)
-            {
-                if (seq != null && seq.delayInSec > 0f)
-                {
-                    allZeroDelay = false;
-                    break;
-                }
-            }
-
-            if (allZeroDelay)
-            {
-                foreach (var seq in animatorSequences)
-                {
-                    if (seq?.animator != null)
-                    {
-                        seq.animator.Play("Appear");
-                        if (seq.uiParticle != null)
-                        {
-                            seq.uiParticle.Play();
-                        }
-                    }
-                }
-                yield break;
-            }
-
-            // Otherwise: play one-by-one, respecting each item's delay (relative to the previous trigger).
-            foreach (var seq in animatorSequences)
-            {
-                if (seq == null || seq.animator == null)
-                    continue;
-
-                if (seq.delayInSec > 0f)
-                    yield return new WaitForSeconds(seq.delayInSec);
-
-                seq.animator.Play("Appear");
-                
-                if (seq.uiParticle != null)
-                {
-                    seq.uiParticle.Play();
-                }
-            }
-        }
     }
 }

--- a/Assets/Scripts/UI/In-game notifications/TraitNotification.cs
+++ b/Assets/Scripts/UI/In-game notifications/TraitNotification.cs
@@ -1,16 +1,13 @@
-using System;
-using System.Collections;
+using GameAssets.ScriptableObjects.Core;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
-using GameAssets.ScriptableObjects.Core;
 
 namespace VisualNovel.UI.Notifications
 {
     using UI;
-    using Animations;
-    
-    public class TraitNotification : GlobalNotification
+
+    public class TraitNotification : AnimatedNotification
     {
         [Header("UI Setup")]
         [SerializeField] private Image traitImage;
@@ -18,18 +15,6 @@ namespace VisualNovel.UI.Notifications
         [SerializeField] private TMP_Text traitDescriptionTextField;
         [SerializeField] private ExtendedButton readButton;
 
-        [Header("Animators")] 
-        [SerializeField] private AnimatorSequence[] animatorSequences;
-
-        [Serializable]
-        public class AnimatorSequence
-        {
-            public UIAnimator animator;
-            public float delayInSec;
-        }
-
-        private Coroutine showNotificationRoutine;
-        
         public void Initialize(TraitSO targetTrait)
         {
             traitImage.sprite = targetTrait.traitIcon;
@@ -38,71 +23,5 @@ namespace VisualNovel.UI.Notifications
         }
 
         public override ExtendedButton ReadButton => readButton;
-        
-        public override void Show()
-        {
-            if (showNotificationRoutine != null)
-            {
-                StopCoroutine(showNotificationRoutine);
-                showNotificationRoutine = null;
-            }
-            showNotificationRoutine = StartCoroutine(ShowNotificationRoutine());
-        }
-
-        public override void Hide()
-        {
-            if (showNotificationRoutine != null)
-            {
-                StopCoroutine(showNotificationRoutine);
-                showNotificationRoutine = null;
-            }
-
-            // hiding everything at once
-            if (animatorSequences == null) return;
-            foreach (var seq in animatorSequences)
-            {
-                if (seq?.animator != null)
-                    seq.animator.Play("Hide");
-            }
-        }
-
-        private IEnumerator ShowNotificationRoutine()
-        {
-            if (animatorSequences == null || animatorSequences.Length == 0)
-                yield break;
-
-            // If ALL delays are zero -> play all at once.
-            bool allZeroDelay = true;
-            foreach (var seq in animatorSequences)
-            {
-                if (seq != null && seq.delayInSec > 0f)
-                {
-                    allZeroDelay = false;
-                    break;
-                }
-            }
-
-            if (allZeroDelay)
-            {
-                foreach (var seq in animatorSequences)
-                {
-                    if (seq?.animator != null)
-                        seq.animator.Play("Appear");
-                }
-                yield break;
-            }
-
-            // Otherwise: play one-by-one, respecting each item's delay (relative to the previous trigger).
-            foreach (var seq in animatorSequences)
-            {
-                if (seq == null || seq.animator == null)
-                    continue;
-
-                if (seq.delayInSec > 0f)
-                    yield return new WaitForSeconds(seq.delayInSec);
-
-                seq.animator.Play("Appear");
-            }
-        }
     }
 }


### PR DESCRIPTION
## Summary
- extract shared animation logic into new `AnimatedNotification` base class
- simplify `ItemNotification` and `TraitNotification` to reuse animation/particle sequence handling
- enable trait notifications to trigger `UIParticle` effects alongside animations

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c56d8c7af0832b854ce04fc79acb86