### PR TITLE
Defer node execution until notifications complete

### DIFF
--- a/Assets/Scripts/UI/UINotificationManager.cs
+++ b/Assets/Scripts/UI/UINotificationManager.cs
@@ -19,6 +19,8 @@ namespace VisualNovel.UI
 
         public static UINotificationManager Instance { get; private set; }
 
+        public bool HasPendingNotifications => currentNotification != null || notificationQueue.Count > 0;
+
         public void Initialize()
         {
             if (Instance != null)


### PR DESCRIPTION
## Summary
- add `HasPendingNotifications` to `UINotificationManager`
- queue graph nodes in `GameFlowManager` and pause progression while notifications are active
- resume queued nodes automatically once notifications are dismissed

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5924b15f4832bb9dedc2c986f6e9e