### PR TITLE
Add inventory UI initializer and controller hook

### DIFF
--- a/Assets/Scripts/UI/UIInventoryInitializer.cs
+++ b/Assets/Scripts/UI/UIInventoryInitializer.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+using VisualNovel.Data;
+
+namespace VisualNovel.UI
+{
+    public class UIInventoryInitializer : MonoBehaviour
+    {
+        [SerializeField] private UICharacterEquipment characterEquipment;
+        [SerializeField] private ExtendedButton hideButton;
+
+        private GameObject inventoryPrefab;
+
+        public void Initialize(Inventory inventory, GameObject prefab)
+        {
+            inventoryPrefab = prefab;
+
+            if (characterEquipment != null)
+            {
+                characterEquipment.Initialize(inventory);
+            }
+
+            if (hideButton != null)
+            {
+                hideButton.OnLeftClick.RemoveListener(Hide);
+                hideButton.OnLeftClick.AddListener(Hide);
+            }
+        }
+
+        private void Hide()
+        {
+            if (UserInterfaceController.Instance != null && inventoryPrefab != null)
+            {
+                UserInterfaceController.Instance.DeleteAdditionalUI(inventoryPrefab);
+            }
+            else
+            {
+                Destroy(gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/UIInventoryInitializer.cs.meta
+++ b/Assets/Scripts/UI/UIInventoryInitializer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 195856927fbeecb4034f45cc689335c5

--- a/Assets/Scripts/UI/UserInterfaceController.cs
+++ b/Assets/Scripts/UI/UserInterfaceController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using VisualNovel.GameFlow;
+using VisualNovel.Data;
 
 namespace VisualNovel.UI
 {
@@ -52,6 +53,23 @@ namespace VisualNovel.UI
 
             Destroy(spawnedUi);
             additionalUIs.Remove(uiPrefab);
+        }
+
+        public void ShowInventory(GameObject inventoryPrefab, Inventory inventory)
+        {
+            if (inventoryPrefab == null)
+            {
+                return;
+            }
+
+            var inventoryUi = SpawnAdditionalUI(inventoryPrefab);
+            if (inventoryUi == null)
+            {
+                return;
+            }
+
+            var initializer = inventoryUi.GetComponent<UIInventoryInitializer>();
+            initializer?.Initialize(inventory, inventoryPrefab);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add UIInventoryInitializer to configure inventory equipment UI and close button
- extend UserInterfaceController with ShowInventory for spawning and initializing the inventory UI
- treat inventory UI as additional UI, removing manual activation/deactivation and deleting via controller

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e5028cec832b86cf47aa84731320