### PR TITLE
Add trinket inventory limits and visualization

### DIFF
--- a/Assets/Scripts/Data/Inventory.cs
+++ b/Assets/Scripts/Data/Inventory.cs
@@ -14,6 +14,7 @@ namespace VisualNovel.Data
     {
         [SerializeField] private List<string> itemGuids = new();
         [SerializeField] private List<string> equippedGuids = new();
+        [SerializeField] private int maxEquippedTrinkets = 1;
         private readonly List<ItemSO> items = new();
         private readonly List<ItemSO> equippedItems = new();
 
@@ -24,6 +25,11 @@ namespace VisualNovel.Data
         /// </summary>
         public IReadOnlyList<ItemSO> Items => items;
         public IReadOnlyList<ItemSO> EquippedItems => equippedItems;
+        public int MaxEquippedTrinkets
+        {
+            get => maxEquippedTrinkets;
+            set => maxEquippedTrinkets = value;
+        }
 
         public void AddItem(ItemSO item)
         {

--- a/Assets/Scripts/Game flow/GameFlowManager.cs
+++ b/Assets/Scripts/Game flow/GameFlowManager.cs
@@ -417,7 +417,7 @@ namespace VisualNovel.GameFlow
                             equip = true;
                         break;
                     case ItemType.Trinket:
-                        if (inventory.EquippedCount(ItemType.Trinket) < 3)
+                        if (inventory.EquippedCount(ItemType.Trinket) < inventory.MaxEquippedTrinkets)
                             equip = true;
                         break;
                 }

--- a/Assets/Scripts/UI/UIPlayerInventoryVisualizer.cs
+++ b/Assets/Scripts/UI/UIPlayerInventoryVisualizer.cs
@@ -1,4 +1,6 @@
+using GameAssets.ScriptableObjects.Core;
 using UnityEngine;
+using VisualNovel.Data;
 
 namespace VisualNovel.UI
 {
@@ -6,6 +8,53 @@ namespace VisualNovel.UI
     {
         [SerializeField] private UIItemVisualizer itemSlotPrefab;
         [SerializeField] private Transform inventoryGrid;
-        [SerializeField] private Transform equippedItemsGrid;
+        [SerializeField] private Transform equippedTrinketsGrid;
+
+        private Inventory inventory;
+
+        public void Initialize(Inventory playerInventory)
+        {
+            inventory = playerInventory;
+            VisualizeEquippedTrinkets();
+            VisualizeInventory();
+        }
+
+        private void VisualizeEquippedTrinkets()
+        {
+            ClearGrid(equippedTrinketsGrid);
+            if (inventory == null) return;
+            foreach (var item in inventory.EquippedItems)
+            {
+                if (item.itemType != ItemType.Trinket) continue;
+                SpawnItem(item, equippedTrinketsGrid);
+            }
+        }
+
+        private void VisualizeInventory()
+        {
+            ClearGrid(inventoryGrid);
+            if (inventory == null) return;
+            foreach (var item in inventory.Items)
+            {
+                if (inventory.IsEquipped(item)) continue;
+                SpawnItem(item, inventoryGrid);
+            }
+        }
+
+        private void SpawnItem(ItemSO item, Transform parent)
+        {
+            if (itemSlotPrefab == null || parent == null) return;
+            var slot = Instantiate(itemSlotPrefab, parent);
+            slot.SetItem(item);
+        }
+
+        private void ClearGrid(Transform grid)
+        {
+            if (grid == null) return;
+            for (int i = grid.childCount - 1; i >= 0; i--)
+            {
+                Destroy(grid.GetChild(i).gameObject);
+            }
+        }
     }
 }

--- a/Assets/Scripts/UI/UIPlayerStatsVisualizer.cs
+++ b/Assets/Scripts/UI/UIPlayerStatsVisualizer.cs
@@ -6,6 +6,7 @@ namespace VisualNovel.UI
     public class UIPlayerStatsVisualizer : MonoBehaviour
     {
         [SerializeField] private UICharacterEquipment characterEquipment;
+        [SerializeField] private UIPlayerInventoryVisualizer playerInventoryVisualizer;
         [SerializeField] private ExtendedButton hideButton;
 
         private GameObject inventoryPrefab;
@@ -17,6 +18,11 @@ namespace VisualNovel.UI
             if (characterEquipment != null)
             {
                 characterEquipment.Initialize(inventory);
+            }
+
+            if (playerInventoryVisualizer != null)
+            {
+                playerInventoryVisualizer.Initialize(inventory);
             }
 
             if (hideButton != null)


### PR DESCRIPTION
## Summary
- Track maxEquippedTrinkets in player inventory
- Use maxEquippedTrinkets when auto-equipping trinkets
- Visualize equipped trinkets and stored items in UI
- Initialize inventory visualizer alongside character equipment

## Testing
- `dotnet build` *(fails: command not found)*
- `mcs -target:library $(find Assets/Scripts -name '*.cs')` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c744ed25ec832b96375544fbe4af08