### PR TITLE
Force layout rebuild before resizing skills section

### DIFF
--- a/Assets/Scripts/Minigames/Combat/UI/SkillsSection.cs
+++ b/Assets/Scripts/Minigames/Combat/UI/SkillsSection.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using GameAssets.ScriptableObjects.Core;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace VisualNovel.Minigames.Combat.UI
 {
@@ -45,6 +46,13 @@ namespace VisualNovel.Minigames.Combat.UI
                 }
             }
 
+            if (skillsGrid is RectTransform skillsGridRect)
+            {
+                // Force the layout system to update before recalculating the layout element size.
+                LayoutRebuilder.ForceRebuildLayoutImmediate(skillsGridRect);
+            }
+
+            // Run the recalculation only after the layout is up to date.
             layoutElementResizer?.Recalculate();
         }
 


### PR DESCRIPTION
## Summary
- force the skills grid layout to rebuild after spawning visualizers
- only recalculate the layout element once the layout is up to date
- add comments clarifying the update order change

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c983dd8928832bb61710de7dcae68f