### PR TITLE
Add action point cost handling for combat skills

### DIFF
--- a/Assets/Game Assets/Scriptable Objects/Core/CombatSkill.cs
+++ b/Assets/Game Assets/Scriptable Objects/Core/CombatSkill.cs
@@ -8,5 +8,8 @@ namespace GameAssets.ScriptableObjects.Core
     {
         [Header("Effects")]
         public int baseDamageBonus;
+
+        [Header("Costs")]
+        public int actionPointsPrice;
     }
 }

--- a/Assets/Scripts/Minigames/Combat/UI/PlayerCombatSkillsPanel.cs
+++ b/Assets/Scripts/Minigames/Combat/UI/PlayerCombatSkillsPanel.cs
@@ -38,8 +38,9 @@ namespace VisualNovel.Minigames.Combat.UI
             IList<BaseSkill> skills,
             string sectionTitle,
             ISet<BaseSkill> baseSkills = null,
-            Action<BaseSkill> onSkillSelected = null,
-            Action<BaseSkill> onSkillDeselected = null)
+            ISet<BaseSkill> activeSkills = null,
+            Func<BaseSkill, bool> onSkillSelected = null,
+            Func<BaseSkill, bool> onSkillDeselected = null)
         {
             if (playerSkillsPanel == null || skillsSectionPrefab == null)
             {
@@ -47,7 +48,7 @@ namespace VisualNovel.Minigames.Combat.UI
             }
 
             var sectionInstance = Instantiate(skillsSectionPrefab, playerSkillsPanel);
-            sectionInstance.Initialize(skills, sectionTitle, baseSkills, onSkillSelected, onSkillDeselected);
+            sectionInstance.Initialize(skills, sectionTitle, baseSkills, activeSkills, onSkillSelected, onSkillDeselected);
             spawnedSections.Add(sectionInstance);
             return sectionInstance;
         }

--- a/Assets/Scripts/Minigames/Combat/UI/SkillsSection.cs
+++ b/Assets/Scripts/Minigames/Combat/UI/SkillsSection.cs
@@ -26,8 +26,9 @@ namespace VisualNovel.Minigames.Combat.UI
             IList<BaseSkill> skills,
             string sectionTitle,
             ISet<BaseSkill> baseSkills = null,
-            Action<BaseSkill> onSkillSelected = null,
-            Action<BaseSkill> onSkillDeselected = null)
+            ISet<BaseSkill> activeSkills = null,
+            Func<BaseSkill, bool> onSkillSelected = null,
+            Func<BaseSkill, bool> onSkillDeselected = null)
         {
             if (sectionTitleText != null)
             {
@@ -47,7 +48,9 @@ namespace VisualNovel.Minigames.Combat.UI
 
                     var visualizer = Instantiate(skillVisualizerPrefab, skillsGrid);
                     var isBaseSkill = baseSkills != null && baseSkills.Contains(skill);
-                    visualizer.Initialize(skill, isBaseSkill, onSkillSelected, onSkillDeselected);
+                    var isActive = activeSkills != null && activeSkills.Contains(skill);
+                    var shouldStartSelected = isBaseSkill || isActive;
+                    visualizer.Initialize(skill, isBaseSkill, shouldStartSelected, isActive, onSkillSelected, onSkillDeselected);
                     spawnedVisualizers.Add(visualizer);
                 }
             }


### PR DESCRIPTION
## Summary
- add an action point price field to combat skills
- track skill action point reservations on the player stats controller so costs persist between rounds
- update the combat skill UI flow to respect available action points and refund costs when deselecting skills

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9a9c9d45c832bb5f05a31085d8ca3